### PR TITLE
Fix accessing out-of-bounds vector data in Looper1X, Looper3, and Looper5

### DIFF
--- a/SickoCV/src/SickoLooper1Exp.cpp
+++ b/SickoCV/src/SickoLooper1Exp.cpp
@@ -705,7 +705,7 @@ struct SickoLooper1Exp : Module {
 // end changes by DanGreen	
 
 				double currResamplePos = 0;
-				double floorCurrResamplePos = 0;
+				int floorCurrResamplePos = 0;
 
 				trackBuffer[LEFT].push_back(tempBuffer[LEFT][0]);
 				trackBuffer[RIGHT].push_back(tempBuffer[RIGHT][0]);
@@ -792,13 +792,6 @@ struct SickoLooper1Exp : Module {
 				else
 					totalSampleC = trackBuffer[LEFT].size();
 				totalSamples = totalSampleC-1;
-
-// begin changes by DanGreen
-				vector<float>().swap(tempBuffer[LEFT]);
-				vector<float>().swap(tempBuffer[RIGHT]);
-				tempBuffer[LEFT].reserve(0);
-				tempBuffer[RIGHT].reserve(0);
-// end changes by DanGreen
 			}
 		}
 		prevSampleRate = sampleRate;
@@ -1196,12 +1189,6 @@ struct SickoLooper1Exp : Module {
 				totalSamples = totalSampleC-1;
 				//	******************************************************************** fine dell'eventuale salto di un passaggio
 
-// begin changes by DanGreen
-				vector<float>().swap(tempBuffer[LEFT]);
-				vector<float>().swap(tempBuffer[RIGHT]);
-				tempBuffer[LEFT].reserve(0);
-				tempBuffer[RIGHT].reserve(0);
-// end changes by DanGreen
 
 			}
 
@@ -1938,12 +1925,8 @@ struct SickoLooper1Exp : Module {
 				eraseWait = false;
 
 // begin changes by DanGreen
-//				trackBuffer[LEFT].resize(0);
-//				trackBuffer[RIGHT].resize(0);
 	 			vector<float>().swap(trackBuffer[LEFT]);
-	 			trackBuffer[LEFT].reserve(0);
 	 			vector<float>().swap(trackBuffer[RIGHT]);
-	 			trackBuffer[RIGHT].reserve(0);
 // end changes by DanGreen
 
 				totalSamples = 0;
@@ -3150,7 +3133,7 @@ struct SickoLooper1Exp : Module {
 				if (xFadeValue < 0) {
 					extraPlaying = false;
 				} else {
-					if (extraPlayPos >= 0 && extraPlayPos < trackBuffer[LEFT].size()) {
+					if (floor(extraPlayPos) >= 1 && (floor(extraPlayPos) + 2) < trackBuffer[LEFT].size()) {
 						currentOutput[LEFT] *= 1-xFadeValue;
 						currentOutput[RIGHT] *= 1-xFadeValue;
 						
@@ -3181,8 +3164,7 @@ struct SickoLooper1Exp : Module {
 				}
 			} else {	// if it's playing full tail, only if direction is FORWARD
 
-				if (extraPlayPos < tailEnd - minTimeSamplesOvs) {
-
+				if (extraPlayPos < tailEnd - minTimeSamplesOvs && floor(extraPlayPos) >= 1 && floor(extraPlayPos)+2 < trackBuffer[LEFT].size()) {
 					/*
 					currentOutput[LEFT] += trackBuffer[LEFT][extraPlayPos];
 					currentOutput[RIGHT] += trackBuffer[RIGHT][extraPlayPos];
@@ -3205,7 +3187,7 @@ struct SickoLooper1Exp : Module {
 						fadeTail = true;
 						fadeTailValue = 1;
 					}
-					if (extraPlayPos < tailEnd) {
+					if (extraPlayPos < tailEnd && floor(extraPlayPos) >= 1 && floor(extraPlayPos)+2 < trackBuffer[LEFT].size()) {
 						fadeTailValue -= fadeTailDelta;
 						//currentOutput[LEFT] += trackBuffer[LEFT][extraPlayPos] * fadeTailValue;
 						//currentOutput[RIGHT] += trackBuffer[RIGHT][extraPlayPos] * fadeTailValue;
@@ -3239,11 +3221,9 @@ struct SickoLooper1Exp : Module {
 				extraRecording = false;
 
 			} else {
-				if (extraRecPos >= trackBuffer[LEFT].size()) {
-					trackBuffer[LEFT].push_back(0.f);
-					trackBuffer[LEFT].push_back(0.f);
-					trackBuffer[RIGHT].push_back(0.f);
-					trackBuffer[RIGHT].push_back(0.f);
+				if ((extraRecPos + 2) >= trackBuffer[LEFT].size()) {
+					trackBuffer[LEFT].resize(extraRecPos + 3, 0.f);
+					trackBuffer[RIGHT].resize(extraRecPos + 3, 0.f);
 				}
 
 				if (recFade) {
@@ -3281,7 +3261,10 @@ struct SickoLooper1Exp : Module {
 				} else {
 					trackBuffer[LEFT][extraRecPos+1] = (trackBuffer[LEFT][extraRecPos+2] + trackBuffer[LEFT][extraRecPos]) / 2;
 					trackBuffer[RIGHT][extraRecPos+1] = (trackBuffer[RIGHT][extraRecPos+2] + trackBuffer[RIGHT][extraRecPos]) / 2;
-					extraRecPos -= sampleCoeff;
+					if (extraRecPos >= sampleCoeff)
+						extraRecPos -= sampleCoeff;
+					else
+						extraRecPos = 0;
 				}
 			}
 		}

--- a/SickoCV/src/SickoLooper3.cpp
+++ b/SickoCV/src/SickoLooper3.cpp
@@ -879,7 +879,7 @@ struct SickoLooper3 : Module {
 					floorCurrResamplePos = floor(currResamplePos);
 				}
 
-				while ( floorCurrResamplePos < tempSampleC ) {
+				while ( floorCurrResamplePos < tempSamples ) {
 					temp = tempBuffer[LEFT][floorCurrResamplePos]* (1-(currResamplePos - floorCurrResamplePos)) + 
 								tempBuffer[LEFT][floorCurrResamplePos+1]*(currResamplePos - floorCurrResamplePos);
 					trackBuffer[track][LEFT].push_back(temp);
@@ -1268,7 +1268,7 @@ struct SickoLooper3 : Module {
 					floorCurrResamplePos = floor(currResamplePos);
 				}
 
-				while ( floorCurrResamplePos < double(tempSampleC) ) {
+				while ( floorCurrResamplePos < tempSamples ) {
 					temp = tempBuffer[LEFT][floorCurrResamplePos]* (1-(currResamplePos - floorCurrResamplePos)) + 
 								tempBuffer[LEFT][floorCurrResamplePos+1]*(currResamplePos - floorCurrResamplePos);
 					trackBuffer[track][LEFT].push_back(temp);
@@ -4384,8 +4384,8 @@ struct SickoLooper3 : Module {
 				case OVERDUBBING:
 
 					if (samplePos[track] >= trackBuffer[track][LEFT].size()) {
-						trackBuffer[track][LEFT].push_back(0.f);
-						trackBuffer[track][RIGHT].push_back(0.f);
+						trackBuffer[track][LEFT].resize(samplePos[track] + 1, 0.f);
+						trackBuffer[track][RIGHT].resize(samplePos[track] + 1, 0.f);
 					}
 
 					if (samplePos[track] >= 0) {
@@ -4481,9 +4481,9 @@ struct SickoLooper3 : Module {
 					extraRecording[track] = false;
 
 				} else {
-					if (extraRecPos[track] >= trackBuffer[track][LEFT].size()) {
-						trackBuffer[track][LEFT].push_back(0.f);
-						trackBuffer[track][RIGHT].push_back(0.f);
+					if ((extraRecPos[track]) >= trackBuffer[track][LEFT].size()) {
+						trackBuffer[track][LEFT].resize(extraRecPos[track] + 1, 0.f);
+						trackBuffer[track][RIGHT].resize(extraRecPos[track] + 1, 0.f);
 					}
 
 					if (recFade[track]) {

--- a/SickoCV/src/SickoLooper3.cpp
+++ b/SickoCV/src/SickoLooper3.cpp
@@ -927,13 +927,6 @@ struct SickoLooper3 : Module {
 					totalSampleC[track] = trackBuffer[track][LEFT].size();
 				totalSamples[track] = totalSampleC[track]-1;
 
-// begin changes by DanGreen
-				vector<float>().swap(tempBuffer[LEFT]);
-				vector<float>().swap(tempBuffer[RIGHT]);
-				tempBuffer[LEFT].reserve(0);
-				tempBuffer[RIGHT].reserve(0);
-// end changes by DanGreen
-
 			}
 		}
 
@@ -1311,13 +1304,6 @@ struct SickoLooper3 : Module {
 				}
 				totalSampleC[track] = trackBuffer[track][LEFT].size();
 				totalSamples[track] = totalSampleC[track]-1;
-
-// begin changes by DanGreen
-				vector<float>().swap(tempBuffer[LEFT]);
-				vector<float>().swap(tempBuffer[RIGHT]);
-				tempBuffer[LEFT].reserve(0);
-				tempBuffer[RIGHT].reserve(0);
-// end changes by DanGreen
 
 			}
 
@@ -1969,8 +1955,6 @@ struct SickoLooper3 : Module {
 //			clickTempBuffer2.clear();
 			vector<float>().swap(clickTempBuffer);
 			vector<float>().swap(clickTempBuffer2);
-			clickTempBuffer.reserve(0);
-			clickTempBuffer2.reserve(0);
 // end changes by DanGreen
 
 			char* pathDup = strdup(path.c_str());
@@ -2009,7 +1993,6 @@ struct SickoLooper3 : Module {
 // begin changes by DanGreen
 			//clickPlayBuffer[slot].clear();
 			vector<float>().swap(clickPlayBuffer[slot]);
-			clickPlayBuffer[slot].reserve(0);
 // end changes by DanGreen
 		}
 	}
@@ -2558,9 +2541,7 @@ struct SickoLooper3 : Module {
 //					trackBuffer[LEFT].resize(0);
 //					trackBuffer[RIGHT].resize(0);
 		 			vector<float>().swap(trackBuffer[track][LEFT]);
-		 			trackBuffer[track][LEFT].reserve(0);
 		 			vector<float>().swap(trackBuffer[track][RIGHT]);
-		 			trackBuffer[track][RIGHT].reserve(0);
 // end changes by DanGreen
 
 					totalSamples[track] = 0;

--- a/SickoCV/src/SickoLooper5.cpp
+++ b/SickoCV/src/SickoLooper5.cpp
@@ -913,7 +913,7 @@ struct SickoLooper5 : Module {
 					floorCurrResamplePos = floor(currResamplePos);
 				}
 
-				while ( floorCurrResamplePos < tempSampleC ) {
+				while ( floorCurrResamplePos < tempSamples ) {
 					temp = tempBuffer[LEFT][floorCurrResamplePos]* (1-(currResamplePos - floorCurrResamplePos)) + 
 								tempBuffer[LEFT][floorCurrResamplePos+1]*(currResamplePos - floorCurrResamplePos);
 					trackBuffer[track][LEFT].push_back(temp);
@@ -960,13 +960,6 @@ struct SickoLooper5 : Module {
 				else
 					totalSampleC[track] = trackBuffer[track][LEFT].size();
 				totalSamples[track] = totalSampleC[track]-1;
-
-// begin changes by DanGreen
-				vector<float>().swap(tempBuffer[LEFT]);
-				vector<float>().swap(tempBuffer[RIGHT]);
-				tempBuffer[LEFT].reserve(0);
-				tempBuffer[RIGHT].reserve(0);
-// end changes by DanGreen
 
 			}
 		}
@@ -1296,7 +1289,7 @@ struct SickoLooper5 : Module {
 					floorCurrResamplePos = floor(currResamplePos);
 				}
 
-				while ( floorCurrResamplePos < double(tempSampleC) ) {
+				while ( floorCurrResamplePos < tempSamples ) {
 					temp = tempBuffer[LEFT][floorCurrResamplePos]* (1-(currResamplePos - floorCurrResamplePos)) + 
 								tempBuffer[LEFT][floorCurrResamplePos+1]*(currResamplePos - floorCurrResamplePos);
 					trackBuffer[track][LEFT].push_back(temp);
@@ -1339,14 +1332,6 @@ struct SickoLooper5 : Module {
 				}
 				totalSampleC[track] = trackBuffer[track][LEFT].size();
 				totalSamples[track] = totalSampleC[track]-1;
-
-// begin changes by DanGreen
-				vector<float>().swap(tempBuffer[LEFT]);
-				vector<float>().swap(tempBuffer[RIGHT]);
-				tempBuffer[LEFT].reserve(0);
-				tempBuffer[RIGHT].reserve(0);
-// end changes by DanGreen
-
 			}
 
 			if (extraSamples[track])
@@ -2098,8 +2083,6 @@ struct SickoLooper5 : Module {
 //			clickTempBuffer2.clear();
 			vector<float>().swap(clickTempBuffer);
 			vector<float>().swap(clickTempBuffer2);
-			clickTempBuffer.reserve(0);
-			clickTempBuffer2.reserve(0);
 // end changes by DanGreen
 
 			char* pathDup = strdup(path.c_str());
@@ -2138,7 +2121,6 @@ struct SickoLooper5 : Module {
 // begin changes by DanGreen
 			//clickPlayBuffer[slot].clear();
 			vector<float>().swap(clickPlayBuffer[slot]);
-			clickPlayBuffer[slot].reserve(0);
 // end changes by DanGreen
 		}
 	}
@@ -2686,9 +2668,7 @@ struct SickoLooper5 : Module {
 //					trackBuffer[LEFT].resize(0);
 //					trackBuffer[RIGHT].resize(0);
 		 			vector<float>().swap(trackBuffer[track][LEFT]);
-		 			trackBuffer[track][LEFT].reserve(0);
 		 			vector<float>().swap(trackBuffer[track][RIGHT]);
-		 			trackBuffer[track][RIGHT].reserve(0);
 // end changes by DanGreen
 
 					totalSamples[track] = 0;
@@ -4512,8 +4492,8 @@ struct SickoLooper5 : Module {
 				case OVERDUBBING:
 
 					if (samplePos[track] >= trackBuffer[track][LEFT].size()) {
-						trackBuffer[track][LEFT].push_back(0.f);
-						trackBuffer[track][RIGHT].push_back(0.f);
+						trackBuffer[track][LEFT].resize(samplePos[track] + 1, 0.f);
+						trackBuffer[track][RIGHT].resize(samplePos[track] + 1, 0.f);
 					}
 
 					if (samplePos[track] >= 0) {
@@ -4609,8 +4589,8 @@ struct SickoLooper5 : Module {
 
 				} else {
 					if (extraRecPos[track] >= trackBuffer[track][LEFT].size()) {
-						trackBuffer[track][LEFT].push_back(0.f);
-						trackBuffer[track][RIGHT].push_back(0.f);
+						trackBuffer[track][LEFT].resize(extraRecPos[track] + 1, 0.f);
+						trackBuffer[track][RIGHT].resize(extraRecPos[track] + 1, 0.f);
 					}
 
 					if (recFade[track]) {


### PR DESCRIPTION
This fixes several places where the track buffer can get written to outside its bounds. This can sometimes overwrite the malloc tags, which causes a crash when the vector is de-allocated.

These crashes can be reproduced on VCV Rack and also on the MetaModule.